### PR TITLE
inclui redes sociais da seplag e substitui seção equipe por textos de sites de governo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -184,125 +184,14 @@ Clique [aqui](blog/posts/20231229_metricas/index.md) para mais detalhes sobre es
 
     </div>
 
-## Conheça nossa equipe { .h2-center }
 
-<div class="grid cards" markdown>
+Aspectos legais e responsabilidades
 
-- <p class="p-center" markdown>![minha_foto](https://res.cloudinary.com/dgll6seyc/image/upload/v1710368355/automatiza-mg/speaker_woman.webp){ .lg .middle .avatar loading=lazy }</p>
+Política de Privacidade
 
+SEPLAG MG 
+Cidade Administrativa
 
-    <p class="p-center" markdown>__Camila Neves__</p>
+Rodovia Papa João Paulo II, 3777 - Serra Verde
+Belo Horizonte, MG - CEP 31630-903
 
-    ---
-
-    Especialista em Políticas Públicas e Gestão Governamental - EPPGG, lotado na Diretoria Central de Desburocratização - DCD. Apaixonado por programação,  Python e tecnologia em geral. Instrutor e monitor no curso de Power Automate.
-
-    <p class="p-center" markdown>
-        [:simple-github:](#){ .lg .middle .light-red .text-larger } [:material-email:](#){ .lg .middle .light-red .text-larger }
-    </p>
-
-- <p class="p-center" markdown>![minha_foto](https://res.cloudinary.com/dgll6seyc/image/upload/v1710368355/automatiza-mg/speaker_woman.webp){ .lg .middle .avatar loading=lazy }</p>
-
-
-    <p class="p-center" markdown>__Ana Flávia__</p>
-
-    ---
-
-    Especialista em Políticas Públicas e Gestão Governamental - EPPGG, lotado na Diretoria Central de Desburocratização - DCD. Apaixonado por programação,  Python e tecnologia em geral. Instrutor e monitor no curso de Power Automate.
-
-    <p class="p-center" markdown>
-        [:simple-github:](#){ .lg .middle .light-red .text-larger } [:material-email:](#){ .lg .middle .light-red .text-larger }
-    </p>
-
-- <p class="p-center" markdown>![minha_foto](https://res.cloudinary.com/dgll6seyc/image/upload/v1710368355/automatiza-mg/speaker_man.webp){ .lg .middle .avatar loading=lazy }</p>
-
-
-    <p class="p-center" markdown>__Yan Vieira do Carmo__</p>
-
-    ---
-
-    Especialista em Políticas Públicas e Gestão Governamental - EPPGG, lotado na Diretoria Central de Desburocratização - DCD. Apaixonado por automação, dados e inteligência artificial. Instrutor e monitor no curso de Power Automate.
-
-    <p class="p-center" markdown>
-        [:simple-github:](#){ .lg .middle .light-red .text-larger } [:material-email:](#){ .lg .middle .light-red .text-larger }
-    </p>
-
-- <p class="p-center" markdown>![minha_foto](https://res.cloudinary.com/dgll6seyc/image/upload/v1710368359/automatiza-mg/avatar_andre.webp){ .lg .middle .avatar loading=lazy }</p>
-
-
-    <p class="p-center" markdown>__André Amorim__</p>
-
-    ---
-
-    EPPGG da Diretoria Central de Desburocratização. Instrutor e monitor no curso de Power Automate. Também estuda gestão e análise de dados, representação do conhecimento, governo aberto e inteligência natural.
-
-    <p class="p-center" markdown>
-        [:simple-github:](#){ .lg .middle .light-red .text-larger } [:material-email:](#){ .lg .middle .light-red .text-larger }
-    </p>
-
-- <p class="p-center" markdown>![minha_foto](https://res.cloudinary.com/dgll6seyc/image/upload/v1710368355/automatiza-mg/speaker_woman.webp){ .lg .middle .avatar loading=lazy }</p>
-
-
-    <p class="p-center" markdown>__Augusta Cora__</p>
-
-    ---
-
-    Especialista em Políticas Públicas e Gestão Governamental - EPPGG, lotado na Diretoria Central de Desburocratização - DCD. Apaixonado por programação,  Python e tecnologia em geral. Instrutor e monitor no curso de Power Automate.
-
-    <p class="p-center" markdown>
-        [:simple-github:](#){ .lg .middle .light-red .text-larger } [:material-email:](#){ .lg .middle .light-red .text-larger }
-    </p>
-
-- <p class="p-center" markdown>![minha_foto](https://res.cloudinary.com/dgll6seyc/image/upload/v1710368358/automatiza-mg/avatar_gabriel.webp){ .lg .middle .avatar loading=lazy }</p>
-
-
-    <p class="p-center" markdown>__Gabriel Braico Dornas__</p>
-
-    ---
-
-    Especialista em Políticas Públicas e Gestão Governamental - EPPGG, lotado na Diretoria Central de Desburocratização - DCD. Apaixonado por programação,  Python e tecnologia em geral. Instrutor e monitor no curso de Power Automate.
-
-    <p class="p-center" markdown>
-        [:simple-github:](#){ .lg .middle .light-red .text-larger } [:material-email:](#){ .lg .middle .light-red .text-larger }
-    </p>
-
-- <p class="p-center" markdown>![minha_foto](https://res.cloudinary.com/dgll6seyc/image/upload/v1710368356/automatiza-mg/avatar_isa.webp){ .lg .middle .avatar loading=lazy }</p>
-
-
-    <p class="p-center" markdown>__Isabela Romancini__</p>
-
-    ---
-
-    Trabalha no Lab.mg. Instrutora e monitora no curso de Power Automate. Especialista em Políticas Públicas e Gestão Governamental – EPPGG e pós-graduada em Governança de TI.
-
-    <p class="p-center" markdown>
-        [:simple-github:](#){ .lg .middle .light-red .text-larger } [:material-email:](#){ .lg .middle .light-red .text-larger }
-    </p>
-
-- <p class="p-center" markdown>![minha_foto](https://res.cloudinary.com/dgll6seyc/image/upload/v1710368357/automatiza-mg/avatar_lucas.webp){ .lg .middle .avatar loading=lazy }</p>
-
-
-    <p class="p-center" markdown>__Lucas Fainblat__</p>
-
-    ---
-
-    Especialista em Políticas Públicas e Gestão Governamental - EPPGG, lotado na Diretoria Central de Desburocratização - DCD. Apaixonado por programação,  Python e tecnologia em geral. Instrutor e monitor no curso de Power Automate.
-
-    <p class="p-center" markdown>
-        [:simple-github:](#){ .lg .middle .light-red .text-larger } [:material-email:](#){ .lg .middle .light-red .text-larger }
-    </p>
-
-- <p class="p-center" markdown>![minha_foto](https://res.cloudinary.com/dgll6seyc/image/upload/v1710368355/automatiza-mg/speaker_woman.webp){ .lg .middle .avatar loading=lazy }</p>
-
-
-    <p class="p-center" markdown>__Maria Laura__</p>
-
-    ---
-
-    Especialista em Políticas Públicas e Gestão Governamental - EPPGG, lotado na Diretoria Central de Desburocratização - DCD. Apaixonado por programação,  Python e tecnologia em geral. Instrutor e monitor no curso de Power Automate.
-
-    <p class="p-center" markdown>
-        [:simple-github:](#){ .lg .middle .light-red .text-larger } [:material-email:](#){ .lg .middle .light-red .text-larger }
-    </p>
-
-</div>

--- a/docs/overrides/index.html
+++ b/docs/overrides/index.html
@@ -53,12 +53,6 @@
                 <span class="dot"></span>
               </a>
             </li>
-            <li>
-              <a href="#conheca-nossa-equipe" class="page-scroll">
-                <span class="menu-title">Equipe</span>
-                <span class="dot"></span>
-              </a>
-            </li>
           </ul>
         </nav>
       </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,14 +102,18 @@ extra_javascript:
 extra: # Footer
   social:
     - icon: fontawesome/brands/instagram
-      name: Instagram Lab.mg.
-      link: https://www.instagram.com/gov.labmg
-    - icon: fontawesome/brands/github-alt
-      name: Repositório Automatiza-mg no GitHub.
-      link: https://github.com/automatiza-mg
-    - icon: simple/linktree
-      name: Página do Lab.mg no linktree.
-      link: https://linktr.ee/lab.mg
+      name: Instagram Seplagmg.
+      link: https://www.instagram.com/seplagmg/
+    - icon: fontawesome/brands/youtube
+      name: Youtube Seplagmg.
+      link: https://www.youtube.com/channel/UCAQXhpTvKIN12u_Ov_kW3qw
+    - icon: fontawesome/brands/facebook
+      name: Página do governomg no Facebook
+      link: https://www.facebook.com/governomg
+    - icon: fontawesome/brands/twitter
+      name: Página do governomg no Twitter
+      link: https://twitter.com/governomg
+      
 
 plugins:
   - git-revision-date-localized:


### PR DESCRIPTION
@gabrielbdornas na [reunião da DCD de hj](https://github.com/automatiza-mg/handbook/issues/80), @YanVieira1905 comentou sobre os requisitos da ASCOM para o site pertencer ao domínio, e pediu para verificar como seria

- [x] redes sociais da seplag
- [x] endereço físico da seplag
- [ ] marca seplag
- [ ] marca governo canto superior direito
- [ ] equipe: seção grande e sem avatares, com textos repetidos, verificar como seria o aproveitamento do espaço para outras infos