### PR TITLE
retorna troca unidade SEI novo modelo

### DIFF
--- a/docs/robos/cria_processo_sei/assets/fluxo.md
+++ b/docs/robos/cria_processo_sei/assets/fluxo.md
@@ -13,5 +13,12 @@ K --> L{Inserir senha}
 L --> M{Aguardar página inicial do SEI}
 M --> N{Fechar mensagens}
 N --> O("`**Login realizado com sucesso**`")
+N --> O("`**Login realizado com sucesso**`")
+O --> P{Necessário troca unidade?}
+P --> |Sim| Q{Troca unidade}
+P --> |Não| R{Cria processo SEI}
+Q --> R
+R --> S
+S("`**Fim**`")
 E[Erro: CPF inválido] --> A
 H[Erro: Órgão indisponível] --> A

--- a/docs/robos/cria_processo_sei/assets/fluxo.md
+++ b/docs/robos/cria_processo_sei/assets/fluxo.md
@@ -1,0 +1,17 @@
+graph TD
+A("`**Início**`") --> B{Verificar CPF}
+B --> C{CPF válido?}
+C --> |Sim| D{Verificar órgão}
+C --> |Não| E{Erro: CPF inválido}
+D --> F{Órgão disponível?}
+F --> |Sim| G{Abrir Chrome}
+F --> |Não| H{Erro: Órgão inexistente}
+G --> I{Aguardar página inicial}
+I --> J{Selecionar órgão}
+J --> K{Inserir login}
+K --> L{Inserir senha}
+L --> M{Aguardar página inicial do SEI}
+M --> N{Fechar mensagens}
+N --> O("`**Login realizado com sucesso**`")
+E[Erro: CPF inválido] --> A
+H[Erro: Órgão indisponível] --> A

--- a/docs/robos/cria_processo_sei/index.md
+++ b/docs/robos/cria_processo_sei/index.md
@@ -26,7 +26,7 @@ tags:
 ??? note "**Clique para ver o fluxo do robô**"
 
     ```mermaid
-    --8<-- "docs/robos/login_sei/assets/fluxo.md"
+    --8<-- "docs/robos/cria_processo_sei/assets/fluxo.md"
     ```
 
 --8<-- "docs/overrides/partials/modelo_robo/requisitos_montando_seu_proprio_robo.md"

--- a/docs/robos/cria_processo_sei/index.md
+++ b/docs/robos/cria_processo_sei/index.md
@@ -1,0 +1,56 @@
+---
+comments: true
+hide:
+  - navigation
+tags:
+  - SEI
+---
+
+# Cria processo no SEI
+
+![type:video](https://www.youtube.com/embed/2GMy8TcuQ6A)
+
+## Informações gerais
+
+| **Desenvolvedor**| Automatiza-mg  |
+| ----------- | ------------------------------------ |
+| **E-mail**       | simplificacao@planejamento.mg.gov.br|
+| **Ferramenta**    | Power Automate Desktop |
+| **Versão Power Automate**    | 2.39.00239.23332 |
+
+- [x] Robô que cria novo processo no SEI.
+- [x] Utiliza os subfluxos de login e troca de unidade no SEI.
+- [x] Permite a escolha da criação de processo público ou restrito
+- [x] Economiza tempo e evita erros.
+
+??? note "**Clique para ver o fluxo do robô**"
+
+    ```mermaid
+    --8<-- "docs/robos/login_sei/assets/fluxo.md"
+    ```
+
+--8<-- "docs/overrides/partials/modelo_robo/requisitos_montando_seu_proprio_robo.md"
+
+<div class="grid" markdown>
+
+[:fontawesome-solid-1: :octicons-copy-16: __Copie o código do robô__](https://raw.githubusercontent.com/automatiza-mg/biblioteca-de-robos/main/robos/site/processo_novo_sei.txt)[^1] e cole em um novo fluxo Power Automate Desktop.
+{ .card }
+
+[:fontawesome-solid-2: :octicons-workflow-24: __Utilize o robô de login no SEI__](../login_sei/#montando-o-seu-robo){ target="_blank" }[^2] em um novo subfluxo chamado `login_sei`.
+{ .card }
+
+[:fontawesome-solid-3: :octicons-workflow-24: __Utilize o robô de troca de unidade no SEI__](../troca_unidade_sei/#montando-o-seu-robo){ target="_blank" }[^2] em um novo subfluxo chamado `troca_unidade`, :warning: caso seja necessário.
+{ .card }
+
+:fontawesome-solid-4::material-application-variable: __Crie as variáveis de entrada__ `tipo_do_processo_criar` e `assunto`.
+{ .card }
+
+:fontawesome-solid-5::material-application-variable: __Crie a variável de entrada__ `hipotese_restricao`, :warning: caso o processo não seja público.
+{ .card }
+
+</div>
+
+--8<-- "docs/overrides/partials/modelo_robo/ajuda.md"
+
+[^1]: Na nova aba que será aberta, basta apertar ++ctrl+a++ para selecionar todo código e ++ctrl+c++ para copiar.
+[^2]: As variáveis de entrada descritas na página do robo para [login no sei](../login_sei/#montando-o-seu-robo) e [troca de unidade no SEI](../troca_unidade_sei/#montando-o-seu-robo) também deverão ser criadas.

--- a/docs/robos/cria_processo_sei/index.md
+++ b/docs/robos/cria_processo_sei/index.md
@@ -42,10 +42,10 @@ tags:
 [:fontawesome-solid-3: :octicons-workflow-24: __Utilize o robô de troca de unidade no SEI__](../troca_unidade_sei/#montando-o-seu-robo){ target="_blank" }[^2] em um novo subfluxo chamado `troca_unidade`, :warning: caso seja necessário.
 { .card }
 
-:fontawesome-solid-4::material-application-variable: __Crie as variáveis de entrada__ `tipo_do_processo_criar` e `assunto`.
+:fontawesome-solid-4::material-application-variable: __Crie as variáveis de entrada__ `tipo_do_processo_criar`[^3] e `assunto`[^4].
 { .card }
 
-:fontawesome-solid-5::material-application-variable: __Crie a variável de entrada__ `hipotese_restricao`, :warning: caso o processo não seja público.
+:fontawesome-solid-5::material-application-variable: __Crie a variável de entrada__ `hipotese_restricao`, :warning: caso o processo não seja público [^5].
 { .card }
 
 </div>
@@ -54,3 +54,6 @@ tags:
 
 [^1]: Na nova aba que será aberta, basta apertar ++ctrl+a++ para selecionar todo código e ++ctrl+c++ para copiar.
 [^2]: As variáveis de entrada descritas na página do robo para [login no sei](../login_sei/#montando-o-seu-robo) e [troca de unidade no SEI](../troca_unidade_sei/#montando-o-seu-robo) também deverão ser criadas.
+[^3]:Deverá ser `público`, `sigiloso` ou `restrito`, de acordo com a categorização do SEI.
+[^4]: É um palavra-chave que localiza o assunto na lista do formulário de criação de processos do SEI.
+[^5]: Se processo for passível de restrição (não for público), incluir a hipótese legal, de acordo com a lista de opções no SEI.

--- a/docs/robos/cria_processo_sei/index.md
+++ b/docs/robos/cria_processo_sei/index.md
@@ -20,7 +20,7 @@ tags:
 
 - [x] Robô que cria novo processo no SEI.
 - [x] Utiliza os subfluxos de login e troca de unidade no SEI.
-- [x] Permite a escolha da criação de processo público ou restrito
+- [x] Permite a escolha da criação de processo público ou restrito.
 - [x] Economiza tempo e evita erros.
 
 ??? note "**Clique para ver o fluxo do robô**"

--- a/docs/robos/troca_unidade_sei/assets/fluxo.md
+++ b/docs/robos/troca_unidade_sei/assets/fluxo.md
@@ -1,0 +1,17 @@
+graph TD
+A("`**Início**`") --> B{Verificar CPF}
+B --> C{CPF válido?}
+C --> |Sim| D{Verificar órgão}
+C --> |Não| E{Erro: CPF inválido}
+D --> F{Órgão disponível?}
+F --> |Sim| G{Abrir Chrome}
+F --> |Não| H{Erro: Órgão inexistente}
+G --> I{Aguardar página inicial}
+I --> J{Selecionar órgão}
+J --> K{Inserir login}
+K --> L{Inserir senha}
+L --> M{Aguardar página inicial do SEI}
+M --> N{Fechar mensagens}
+N --> O("`**Login realizado com sucesso**`")
+E[Erro: CPF inválido] --> A
+H[Erro: Órgão indisponível] --> A

--- a/docs/robos/troca_unidade_sei/assets/fluxo.md
+++ b/docs/robos/troca_unidade_sei/assets/fluxo.md
@@ -13,5 +13,11 @@ K --> L{Inserir senha}
 L --> M{Aguardar página inicial do SEI}
 M --> N{Fechar mensagens}
 N --> O("`**Login realizado com sucesso**`")
+O --> P{Necessário troca unidade?}
+P --> |Sim| Q{Troca unidade}
+P --> |Não| R{Realiza próxima ação}
+Q --> R
+R --> S
+S("`**Fim**`")
 E[Erro: CPF inválido] --> A
 H[Erro: Órgão indisponível] --> A

--- a/docs/robos/troca_unidade_sei/index.md
+++ b/docs/robos/troca_unidade_sei/index.md
@@ -1,0 +1,52 @@
+---
+comments: true
+hide:
+  - navigation
+tags:
+  - SEI
+---
+
+# Troca de unidade no SEI
+
+![type:video](https://www.youtube.com/embed/2GMy8TcuQ6A)
+
+## Informações gerais
+
+| **Desenvolvedor**| Automatiza-mg  |
+| ----------- | ------------------------------------ |
+| **E-mail**       | simplificacao@planejamento.mg.gov.br|
+| **Ferramenta**    | Power Automate Desktop |
+| **Versão Power Automate**    | 2.39.00239.23332 |
+
+- [x] Robô que troca a unidade do SEI.
+- [x] Utiliza subfluxo de login do SEI.
+- [x] Aguarda o carregamento das páginas para garantir que tudo esteja certo.
+- [x] Economiza tempo e evita erros.
+
+??? note "**Clique para ver o fluxo do robô**"
+
+    ```mermaid
+    --8<-- "docs/robos/troca_unidade_sei/assets/fluxo.md"
+    ```
+
+--8<-- "docs/overrides/partials/modelo_robo/requisitos_montando_seu_proprio_robo.md"
+
+<div class="grid" markdown>
+
+[:fontawesome-solid-1: :octicons-copy-16: __Copie o código do robô__](https://raw.githubusercontent.com/automatiza-mg/biblioteca-de-robos/main/robos/site/troca_unidade_sei.txt)[^1] e cole em um novo fluxo Power Automate Desktop.
+{ .card }
+
+:fontawesome-solid-2: :material-application-variable: __Crie a variável de entrada__ `unidade_sei`[^2].
+{ .card }
+
+[:fontawesome-solid-3: :octicons-workflow-24: __Utilize o robô de login no SEI__](../login_sei/#montando-o-seu-robo){ target="_blank" }[^3] em um novo subfluxo chamado `login_sei`.
+{ .card }
+
+</div>
+
+--8<-- "docs/overrides/partials/modelo_robo/ajuda.md"
+
+[^1]: Na nova aba que será aberta, basta apertar ++ctrl+a++ para selecionar todo código e ++ctrl+c++ para copiar.
+[^2]: Unidade desejada do SEI.
+[^3]: Seguir as instruções da página do robô de login no SEI para colar seu código e criar as variáveis necessárias (login_SEI, senha_SEI e orgao_SEI)
+


### PR DESCRIPTION
see https://github.com/automatiza-mg/automatizacoes/issues/106
@gabrielbdornas veja por favor
- [x] os fluxos, pq eu não tinha conseguido fazer a IA criar uma visualização correta do subfluxo específico (i.e. `troca_unidade_sei`, `cria_processo_sei`), acho que por que o código está cheio de comentários em linguagem natural
- [x] o encadeamento dos códigos de processo: no modelo antigo, eu tinha separado em [main]+[cria novo]+[acessa processo existente], e a mesma página mostrava os subfluxos , veja:
![image](https://github.com/automatiza-mg/automatizacoes/assets/52294411/37a34d91-bee1-4588-9280-015c4a564d2b)

@gabrielbdornas por que eu tinha separado? o Yan tinha feito um **único código para ambas situações: processo novo e processo existente**, mas **ia ficar faltando uma variável se o caso fosse a criação de um novo processo**, veja rodapé na imagem abaixo (o usuário teria que editar o código, eu registrei isso em https://github.com/automatiza-mg/automatizacoes/issues/77):
![image](https://github.com/automatiza-mg/automatizacoes/assets/52294411/425b08c0-6951-4f48-8697-91a99525e4c8)

